### PR TITLE
Better delineate speech title and speaker's name

### DIFF
--- a/src/templates/layouts/website/homepage.jade
+++ b/src/templates/layouts/website/homepage.jade
@@ -31,7 +31,11 @@ block content
 				ul
 					if current_event.schedule
 						for speaker in current_event.schedule.all
-							li {{speaker.time|date:"g:iA"|lower }}: {{speaker.title}} {{speaker.speaker}}
+							if speaker.speaker
+								li {{speaker.time|date:"g:iA"|lower }}: {{speaker.title}} - {{speaker.speaker}}
+							else
+								li {{speaker.time|date:"g:iA"|lower }}: {{speaker.title}}
+								
 
 
 	.details-general


### PR DESCRIPTION
I find it difficult to see where the speech title ends and speakers name begins.  This change simply adds a `-` between them, but more complex solutions could be made (colour or layout?).

It appears as though the "Meet + Greet" and "Pizza" entries are just a `speaker` with no `speaker` so I just removed the whole bit if it's not there.